### PR TITLE
Feat/4 search result UI

### DIFF
--- a/docs/ncbi_api_report_seq5.md
+++ b/docs/ncbi_api_report_seq5.md
@@ -1,0 +1,124 @@
+# NCBI API 検証結果レポート — 配列 5
+
+> 検証日: 2026-03-04  
+> 対象配列: `CTGTTGATGCCGTTTCC...` (660 bp、`TGTTGATGCCGTTTCC` 繰り返しパターン)  
+> スクリプト: [`ncbi_api_test.py`](../scripts/ncbi_api_test.py)
+
+---
+
+## 結果サマリー
+
+| # | API | 結果 |
+|:-:|:----|:-----|
+| 1 | **ESearch** | ⚠️ 0 件ヒット |
+| 2 | **BLAST (blastn)** 通常検索 | ✅ **10 件ヒット（最高カバレッジ 115.5%、一致率 71.8%）** |
+
+> [!IMPORTANT]
+> 通常検索（megablast）で **高カバレッジのヒットが多数得られた**。緩和検索は不要だった。  
+> カバレッジが 100% を超えているのは、ギャップを含むアラインメントにより Subject 配列がクエリより長い領域にマッチしているため。
+
+---
+
+## BLAST ヒット一覧（上位 10 件 — カバレッジ順）
+
+| # | Accession | E-value | Score | 一致率 | カバレッジ | 生物種・説明 |
+|:-:|:----------|:--------|:------|:-------|:----------|:------------|
+| 1 | **OZ078405** | **3.20e-93** | **357.5** | **71.8%** | **115.5%** | ***Lampetra fluviatilis*** (ヨーロッパカワヤツメ) |
+| 2 | OZ078405 | 3.20e-93 | 357.5 | 71.8% | 115.5% | *Lampetra fluviatilis* (別領域) |
+| 3 | OZ408726 | 2.30e-63 | 258.3 | 66.8% | 114.6% | *Tylodina rafinesquii* (ウミウシ目) |
+| 4 | XM_072500567 | 7.54e-38 | 173.5 | 66.8% | 114.4% | *Scyliorhinus torazame* (トラザメ) |
+| 5 | OZ078325 | 2.46e-31 | 151.9 | 68.8% | 109.5% | *Lampetra planeri* (ヨーロッパスナヤツメ) |
+| 6 | XR_012931291 | 5.80e-33 | 156.4 | 66.2% | 106.1% | *Petromyzon marinus* (ウミヤツメ) |
+| 7 | XR_012931292 | 5.80e-33 | 156.4 | 66.2% | 106.1% | *Petromyzon marinus* (ウミヤツメ) |
+| 8 | XM_076057702 | 5.80e-33 | 156.4 | 66.2% | 106.1% | *Petromyzon marinus* (ウミヤツメ) |
+| 9 | XM_076057701 | 5.80e-33 | 156.4 | 66.2% | 106.1% | *Petromyzon marinus* (ウミヤツメ) |
+| 10 | XM_023271605 | 1.28e-47 | 205.1 | 70.0% | 105.1% | *Amphiprion ocellaris* (カクレクマノミ) |
+
+---
+
+## 上位ヒットのアラインメント
+
+### 1 位: OZ078405 — *Lampetra fluviatilis*（ヨーロッパカワヤツメ）
+
+```
+一致率: 71.8% (569/792 bp)   カバレッジ: 115.5%   E-value: 3.20e-93
+配列長: 37,001,432 bp
+
+Query:   GTTGATGCCGTTTCCGAT---GTTGATGCCGTTTCCTAT---GTTGATGCCGTTTCCGAT...
+Match:   ||||||||||| |||| |   ||||||||||| |||  |   ||||||||||| |||| |...
+Subject: GTTGATGCCGTGTCCGCTGTGGTTGATGCCGTGTCCACTGTGGTTGATGCCGTGTCCGCT...
+```
+
+クエリ中の `TGTTGATGCCGTTTCC` リピートが、Subject 側の `TGTTGATGCCGTGTCC` リピートに対応。
+主な塩基差異: クエリ `TTT` → Subject `TGT`、クエリ末尾 `GAT/TAT` → Subject `GCT/ACT`。
+
+### 3 位: OZ408726 — *Tylodina rafinesquii*（ウミウシ目巻貝）
+
+```
+一致率: 66.8% (525/786 bp)   カバレッジ: 114.6%   E-value: 2.30e-63
+
+Query:   TGTTGATGCCGTTTCCGATGTTGATGCCGTTTC------CTATGTTGATGCCGTTTCC...
+Match:   ||||||||||||  | | ||||||||| ||  |        |||||||||||||  | |...
+Subject: TGTTGATGCCGTGCCAGCTGTTGATGCTGTGACAGTGGTGGATGTTGATGCCGTGCCA...
+```
+
+---
+
+## 考察
+
+### 配列の特徴
+
+| 項目 | 値 |
+|:---|:---|
+| 配列長 | 660 bp |
+| GC 含量 | G: 173, C: 135, T: 220, A: 32 → **G+C = 46.7%** |
+| 反復単位 | `TGTTGATGCCGTTTCC` (16 bp) × 約 41 リピート |
+| バリエーション | 末尾が `GAT` / `TAT` で交互に出現 |
+
+### ヒットの特徴
+
+- **全 10 件が高カバレッジ（105〜115%）** — 配列全体にわたってマッチする既知配列が存在
+- **E-value が極めて低い**（10^-93 〜 10^-31）→ **統計的に非常に有意**
+- ヒット生物は **ヤツメウナギ科** が圧倒的に多い（*Lampetra*, *Petromyzon*）
+
+### ヒット生物種の分類
+
+| 分類群 | 生物種 | ヒット数 |
+|:---|:---|:---:|
+| **ヤツメウナギ目** | *Lampetra fluviatilis*, *L. planeri*, *Petromyzon marinus* | **7 件** |
+| 軟骨魚類 | *Scyliorhinus torazame* (トラザメ) | 1 件 |
+| 腹足類 | *Tylodina rafinesquii* (ウミウシ) | 1 件 |
+| 硬骨魚類 | *Amphiprion ocellaris* (カクレクマノミ) | 1 件 |
+
+> [!NOTE]
+> ヤツメウナギは脊椎動物の中でも最も原始的な無顎類に属する。このリピート配列がヤツメウナギ科に集中してヒットすることは、**原始的な脊椎動物に共通するゲノムリピート構造**の存在を示唆する可能性がある。
+
+### 全配列の横断比較
+
+| 項目 | 配列 1 | 配列 2 | 配列 3 | 配列 4 | **配列 5** |
+|:-----|:---:|:---:|:---:|:---:|:---:|
+| 配列長 | 30bp | 96bp | 108bp | 208bp | **660bp** |
+| 通常検索 | 0 | 0 | 18 | 5 | **10** |
+| 最高カバレッジ | 100% | 95.8% | 99.1% | 22.1% | **115.5%** |
+| 最高一致率 | 100% | 83.7% | 73.8% | 84.8% | **71.8%** |
+| ベスト E-value | 0.137 | 4.76e-15 | 2.54e-07 | 0.570 | **3.20e-93** |
+| 統計的有意性 | 低 | 高 | やや高 | 低 | **非常に高** |
+
+**配列 5 は全検証中で最も統計的に有意な結果**。E-value が 10^-93 と極めて低く、ヤツメウナギ科ゲノムに実在するリピート配列との強い類似性が確認された。
+
+---
+
+## DB 統計
+
+| 指標 | 値 |
+|:---|:---|
+| DB 配列数 | 122,348,708 |
+| DB 総塩基数 | 1,068,532,645,866 (~1 兆 bp) |
+
+---
+
+## 参考
+
+- 検証スクリプト: [`ncbi_api_test.py`](../scripts/ncbi_api_test.py)
+- プロセス解説: [`blast_process.md`](./blast_process.md)
+- 過去のレポート: [配列 1](./ncbi_api_report.md) / [配列 2](./ncbi_api_report_seq2.md) / [配列 3](./ncbi_api_report_seq3.md) / [配列 4](./ncbi_api_report_seq4.md)

--- a/lib/app/screens/input_screen.dart
+++ b/lib/app/screens/input_screen.dart
@@ -1,0 +1,338 @@
+import 'package:flutter/material.dart';
+import 'package:genoru/app/theme/app_theme.dart';
+import 'package:genoru/app/widgets/dna_background.dart';
+
+class InputScreen extends StatefulWidget {
+  const InputScreen({super.key});
+
+  @override
+  State<InputScreen> createState() => _InputScreenState();
+}
+
+class _InputScreenState extends State<InputScreen>
+    with SingleTickerProviderStateMixin {
+  final TextEditingController _textController = TextEditingController();
+  final int _maxLength = 200;
+  String? _errorText;
+  bool _isButtonEnabled = false;
+
+  late AnimationController _pulseController;
+  late Animation<double> _pulseAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _textController.addListener(_onTextChanged);
+
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 2000),
+    )..repeat(reverse: true);
+
+    _pulseAnimation = Tween<double>(begin: 0.8, end: 1.0).animate(
+      CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  void _onTextChanged() {
+    final text = _textController.text;
+    setState(() {
+      if (text.isEmpty) {
+        _errorText = null;
+        _isButtonEnabled = false;
+      } else if (text.length > _maxLength) {
+        _errorText = '$_maxLength文字以内で入力してください';
+        _isButtonEnabled = false;
+      } else {
+        _errorText = null;
+        _isButtonEnabled = true;
+      }
+    });
+  }
+
+  void _onConvertPressed() {
+    final text = _textController.text.trim();
+    if (text.isEmpty) {
+      setState(() {
+        _errorText = '文字を入力してください';
+      });
+      return;
+    }
+    if (text.length > _maxLength) {
+      setState(() {
+        _errorText = '$_maxLength文字以内で入力してください';
+      });
+      return;
+    }
+
+    // TODO: DNA変換・結果画面への遷移は別ブランチで実装
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currentLength = _textController.text.length;
+
+    return Scaffold(
+      body: Stack(
+        children: [
+          // DNA螺旋アニメーション背景
+          const DnaBackground(),
+
+          // メインコンテンツ
+          SafeArea(
+            child: Center(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const SizedBox(height: 40),
+
+                    // ── ロゴ・タイトル ──
+                    AnimatedBuilder(
+                      animation: _pulseAnimation,
+                      builder: (context, child) {
+                        return Transform.scale(
+                          scale: _pulseAnimation.value,
+                          child: child,
+                        );
+                      },
+                      child: ShaderMask(
+                        shaderCallback:
+                            (bounds) => const LinearGradient(
+                              colors: [
+                                AppTheme.primaryGreen,
+                                AppTheme.accentCyan,
+                              ],
+                            ).createShader(bounds),
+                        child: Text(
+                          '🧬 ゲノる',
+                          style: Theme.of(
+                            context,
+                          ).textTheme.headlineLarge?.copyWith(
+                            fontSize: 36,
+                            fontWeight: FontWeight.w800,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+
+                    const SizedBox(height: 8),
+                    Text(
+                      'あなたの言葉をDNAに変換しよう',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+
+                    const SizedBox(height: 48),
+
+                    // ── 入力カード ──
+                    Container(
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(24),
+                        gradient: LinearGradient(
+                          begin: Alignment.topLeft,
+                          end: Alignment.bottomRight,
+                          colors: [
+                            AppTheme.cardDark.withValues(alpha: 0.8),
+                            AppTheme.surfaceDark.withValues(alpha: 0.6),
+                          ],
+                        ),
+                        border: Border.all(
+                          color: AppTheme.primaryGreen.withValues(alpha: 0.15),
+                          width: 1,
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: AppTheme.primaryGreen.withValues(
+                              alpha: 0.05,
+                            ),
+                            blurRadius: 30,
+                            spreadRadius: 5,
+                          ),
+                        ],
+                      ),
+                      padding: const EdgeInsets.all(24),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              const Icon(
+                                Icons.edit_note_rounded,
+                                color: AppTheme.primaryGreen,
+                                size: 24,
+                              ),
+                              const SizedBox(width: 8),
+                              Text(
+                                '文字列を入力',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .headlineMedium
+                                    ?.copyWith(fontSize: 18),
+                              ),
+                            ],
+                          ),
+
+                          const SizedBox(height: 16),
+
+                          // テキスト入力欄
+                          TextField(
+                            controller: _textController,
+                            maxLines: 5,
+                            minLines: 3,
+                            style: Theme.of(
+                              context,
+                            ).textTheme.bodyLarge?.copyWith(height: 1.6),
+                            decoration: InputDecoration(
+                              hintText: '好きな言葉、名前、文章を入力…',
+                              errorText: _errorText,
+                              errorMaxLines: 2,
+                            ),
+                          ),
+
+                          const SizedBox(height: 12),
+
+                          // 文字数カウンター
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: [
+                              Text(
+                                '$currentLength / $_maxLength',
+                                style: TextStyle(
+                                  color:
+                                      currentLength > _maxLength
+                                          ? AppTheme.errorRed
+                                          : AppTheme.textSecondary,
+                                  fontSize: 13,
+                                  fontWeight:
+                                      currentLength > _maxLength
+                                          ? FontWeight.w600
+                                          : FontWeight.normal,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+
+                    const SizedBox(height: 32),
+
+                    // ── DNAに変換するボタン ──
+                    SizedBox(
+                      width: double.infinity,
+                      height: 56,
+                      child: AnimatedContainer(
+                        duration: const Duration(milliseconds: 300),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(16),
+                          gradient:
+                              _isButtonEnabled
+                                  ? const LinearGradient(
+                                    colors: [
+                                      AppTheme.primaryGreen,
+                                      AppTheme.accentCyan,
+                                    ],
+                                  )
+                                  : LinearGradient(
+                                    colors: [
+                                      Colors.grey.shade800,
+                                      Colors.grey.shade700,
+                                    ],
+                                  ),
+                          boxShadow:
+                              _isButtonEnabled
+                                  ? [
+                                    BoxShadow(
+                                      color: AppTheme.primaryGreen.withValues(
+                                        alpha: 0.4,
+                                      ),
+                                      blurRadius: 20,
+                                      offset: const Offset(0, 4),
+                                    ),
+                                  ]
+                                  : [],
+                        ),
+                        child: ElevatedButton.icon(
+                          onPressed:
+                              _isButtonEnabled ? _onConvertPressed : null,
+                          icon: const Icon(Icons.transform_rounded, size: 22),
+                          label: const Text(
+                            'DNAに変換する',
+                            style: TextStyle(
+                              fontSize: 17,
+                              fontWeight: FontWeight.w700,
+                              letterSpacing: 1,
+                            ),
+                          ),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.transparent,
+                            disabledBackgroundColor: Colors.transparent,
+                            shadowColor: Colors.transparent,
+                            foregroundColor: Colors.white,
+                            disabledForegroundColor: Colors.grey.shade500,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+
+                    const SizedBox(height: 24),
+
+                    // ── 注意文 ──
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
+                      ),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(12),
+                        color: AppTheme.surfaceDark.withValues(alpha: 0.5),
+                      ),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.info_outline_rounded,
+                            color: AppTheme.textSecondary.withValues(
+                              alpha: 0.7,
+                            ),
+                            size: 18,
+                          ),
+                          const SizedBox(width: 10),
+                          Expanded(
+                            child: Text(
+                              '個人情報は入力しないでください。\n同じ文字列は同じDNA配列に変換されます。',
+                              style: TextStyle(
+                                color: AppTheme.textSecondary.withValues(
+                                  alpha: 0.8,
+                                ),
+                                fontSize: 12,
+                                height: 1.5,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+
+                    const SizedBox(height: 40),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/screens/input_screen.dart
+++ b/lib/app/screens/input_screen.dart
@@ -12,7 +12,7 @@ class InputScreen extends StatefulWidget {
 class _InputScreenState extends State<InputScreen>
     with SingleTickerProviderStateMixin {
   final TextEditingController _textController = TextEditingController();
-  final int _maxLength = 200;
+  final int _maxLength = 100;
   String? _errorText;
   bool _isButtonEnabled = false;
 
@@ -172,7 +172,7 @@ class _InputScreenState extends State<InputScreen>
                               ),
                               const SizedBox(width: 8),
                               Text(
-                                '文字列を入力',
+                                'DNAに変換したい文字列を入力',
                                 style: Theme.of(context)
                                     .textTheme
                                     .headlineMedium
@@ -311,7 +311,7 @@ class _InputScreenState extends State<InputScreen>
                           const SizedBox(width: 10),
                           Expanded(
                             child: Text(
-                              '個人情報は入力しないでください。\n同じ文字列は同じDNA配列に変換されます。',
+                              '個人情報は入力しないでください。',
                               style: TextStyle(
                                 color: AppTheme.textSecondary.withValues(
                                   alpha: 0.8,

--- a/lib/app/screens/input_screen.dart
+++ b/lib/app/screens/input_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:genoru/app/screens/result_screen.dart';
 import 'package:genoru/app/theme/app_theme.dart';
 import 'package:genoru/app/widgets/dna_background.dart';
 
@@ -12,7 +13,7 @@ class InputScreen extends StatefulWidget {
 class _InputScreenState extends State<InputScreen>
     with SingleTickerProviderStateMixin {
   final TextEditingController _textController = TextEditingController();
-  final int _maxLength = 100;
+  final int _maxLength = 200;
   String? _errorText;
   bool _isButtonEnabled = false;
 
@@ -72,7 +73,13 @@ class _InputScreenState extends State<InputScreen>
       return;
     }
 
-    // TODO: DNA変換・結果画面への遷移は別ブランチで実装
+    // TODO: ATGC変換ロジックを実装する
+    final dnaSequence = '';
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ResultScreen(inputText: text, dnaSequence: dnaSequence),
+      ),
+    );
   }
 
   @override
@@ -172,7 +179,7 @@ class _InputScreenState extends State<InputScreen>
                               ),
                               const SizedBox(width: 8),
                               Text(
-                                'DNAに変換したい文字列を入力',
+                                '文字列を入力',
                                 style: Theme.of(context)
                                     .textTheme
                                     .headlineMedium
@@ -311,7 +318,7 @@ class _InputScreenState extends State<InputScreen>
                           const SizedBox(width: 10),
                           Expanded(
                             child: Text(
-                              '個人情報は入力しないでください。',
+                              '個人情報は入力しないでください。\n同じ文字列は同じDNA配列に変換されます。',
                               style: TextStyle(
                                 color: AppTheme.textSecondary.withValues(
                                   alpha: 0.8,

--- a/lib/app/screens/input_screen.dart
+++ b/lib/app/screens/input_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:genoru/app/screens/result_screen.dart';
+import 'package:genoru/app/utils/dna_converter.dart';
 import 'package:genoru/app/theme/app_theme.dart';
 import 'package:genoru/app/widgets/dna_background.dart';
 
@@ -73,8 +74,7 @@ class _InputScreenState extends State<InputScreen>
       return;
     }
 
-    // TODO: ATGC変換ロジックを実装する
-    final dnaSequence = '';
+    final dnaSequence = DnaConverter.convertToDna(text);
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => ResultScreen(inputText: text, dnaSequence: dnaSequence),

--- a/lib/app/screens/input_screen.dart
+++ b/lib/app/screens/input_screen.dart
@@ -75,11 +75,21 @@ class _InputScreenState extends State<InputScreen>
     }
 
     final dnaSequence = DnaConverter.convertToDna(text);
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => ResultScreen(inputText: text, dnaSequence: dnaSequence),
-      ),
-    );
+    Navigator.of(context)
+        .push(
+          MaterialPageRoute(
+            builder:
+                (_) => ResultScreen(inputText: text, dnaSequence: dnaSequence),
+          ),
+        )
+        .then((_) {
+          if (!mounted) return;
+          _textController.clear();
+          setState(() {
+            _errorText = null;
+            _isButtonEnabled = false;
+          });
+        });
   }
 
   @override

--- a/lib/app/screens/result_screen.dart
+++ b/lib/app/screens/result_screen.dart
@@ -319,7 +319,7 @@ class ResultScreen extends StatelessWidget {
     return buffer.toString();
   }
 
-  /// 各塩基の割合を表示するウィジェット
+  /// 各塩基の割合を 2×2 グリッドで表示
   Widget _buildComposition(BuildContext context) {
     final total = dnaSequence.length;
     final counts = {'A': 0, 'T': 0, 'G': 0, 'C': 0};
@@ -328,84 +328,57 @@ class ResultScreen extends StatelessWidget {
     }
 
     const baseColors = {
-      'A': Color(0xFF4CAF50), // 緑
-      'T': Color(0xFFFF7043), // オレンジ
-      'G': Color(0xFF42A5F5), // 青
-      'C': Color(0xFFAB47BC), // 紫
+      'A': Color(0xFF4CAF50),
+      'T': Color(0xFFFF7043),
+      'G': Color(0xFF42A5F5),
+      'C': Color(0xFFAB47BC),
     };
 
-    return Column(
-      children:
-          ['A', 'T', 'G', 'C'].map((base) {
-            final count = counts[base]!;
-            final ratio = total > 0 ? count / total : 0.0;
-            return _buildBaseRow(
-              context,
-              base: base,
-              count: count,
-              ratio: ratio,
-              color: baseColors[base]!,
-            );
-          }).toList(),
-    );
-  }
-
-  Widget _buildBaseRow(
-    BuildContext context, {
-    required String base,
-    required int count,
-    required double ratio,
-    required Color color,
-  }) {
-    final pct = (ratio * 100).toStringAsFixed(1);
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 6),
-      child: Row(
+    Widget cell(String base) {
+      final ratio = total > 0 ? counts[base]! / total : 0.0;
+      final pct = (ratio * 100).toStringAsFixed(1);
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
         children: [
-          // 塩基ラベル
-          SizedBox(
-            width: 28,
-            child: Text(
-              base,
-              style: TextStyle(
-                color: color,
-                fontSize: 18,
-                fontWeight: FontWeight.w800,
-                fontFamily: 'monospace',
-              ),
+          Text(
+            base,
+            style: TextStyle(
+              color: baseColors[base],
+              fontSize: 18,
+              fontWeight: FontWeight.w800,
+              fontFamily: 'monospace',
             ),
           ),
-          const SizedBox(width: 8),
-          // プログレスバー
-          Expanded(
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(6),
-              child: SizedBox(
-                height: 12,
-                child: LinearProgressIndicator(
-                  value: ratio,
-                  backgroundColor: AppTheme.cardDark,
-                  valueColor: AlwaysStoppedAnimation<Color>(color),
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(width: 12),
-          // パーセント
-          SizedBox(
-            width: 56,
-            child: Text(
-              '$pct%',
-              textAlign: TextAlign.right,
-              style: TextStyle(
-                color: AppTheme.textSecondary.withValues(alpha: 0.9),
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-              ),
+          const SizedBox(width: 6),
+          Text(
+            '$pct%',
+            style: TextStyle(
+              color: AppTheme.textSecondary.withValues(alpha: 0.9),
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
             ),
           ),
         ],
-      ),
+      );
+    }
+
+    return Column(
+      children: [
+        Row(
+          children: [
+            Expanded(child: Center(child: cell('A'))),
+            Expanded(child: Center(child: cell('T'))),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(child: Center(child: cell('G'))),
+            Expanded(child: Center(child: cell('C'))),
+          ],
+        ),
+      ],
     );
   }
 

--- a/lib/app/screens/result_screen.dart
+++ b/lib/app/screens/result_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:genoru/app/screens/search_loading_screen.dart';
 import 'package:genoru/app/theme/app_theme.dart';
 import 'package:genoru/app/widgets/dna_background.dart';
 
@@ -205,15 +206,12 @@ class ResultScreen extends StatelessWidget {
                             ),
                             child: ElevatedButton.icon(
                               onPressed: () {
-                                // TODO: NCBI BLAST 検索を実装する
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content: const Text('この機能は準備中です'),
-                                    backgroundColor: AppTheme.surfaceDark,
-                                    behavior: SnackBarBehavior.floating,
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(12),
-                                    ),
+                                Navigator.of(context).push(
+                                  MaterialPageRoute(
+                                    builder:
+                                        (_) => SearchLoadingScreen(
+                                          dnaSequence: dnaSequence,
+                                        ),
                                   ),
                                 );
                               },

--- a/lib/app/screens/result_screen.dart
+++ b/lib/app/screens/result_screen.dart
@@ -1,0 +1,377 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:genoru/app/theme/app_theme.dart';
+import 'package:genoru/app/widgets/dna_background.dart';
+
+/// DNA 変換結果を表示する画面
+class ResultScreen extends StatelessWidget {
+  final String inputText;
+  final String dnaSequence;
+
+  const ResultScreen({
+    super.key,
+    required this.inputText,
+    required this.dnaSequence,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          // DNA螺旋アニメーション背景
+          const DnaBackground(),
+
+          // メインコンテンツ
+          SafeArea(
+            child: Column(
+              children: [
+                // ── AppBar 風ヘッダー ──
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 8,
+                  ),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        icon: const Icon(
+                          Icons.arrow_back_ios_rounded,
+                          color: AppTheme.textPrimary,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      ShaderMask(
+                        shaderCallback:
+                            (bounds) => const LinearGradient(
+                              colors: [
+                                AppTheme.primaryGreen,
+                                AppTheme.accentCyan,
+                              ],
+                            ).createShader(bounds),
+                        child: Text(
+                          '🧬 変換結果',
+                          style: Theme.of(
+                            context,
+                          ).textTheme.headlineMedium?.copyWith(
+                            fontSize: 22,
+                            fontWeight: FontWeight.w700,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+                // ── スクロール可能なカードエリア ──
+                Expanded(
+                  child: SingleChildScrollView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.symmetric(horizontal: 24),
+                    child: Column(
+                      children: [
+                        const SizedBox(height: 16),
+
+                        // ── 入力テキストカード ──
+                        _buildCard(
+                          context,
+                          icon: Icons.text_fields_rounded,
+                          title: '入力テキスト',
+                          child: SelectableText(
+                            inputText,
+                            style: Theme.of(
+                              context,
+                            ).textTheme.bodyLarge?.copyWith(height: 1.6),
+                          ),
+                        ),
+
+                        const SizedBox(height: 20),
+
+                        // ── DNA 配列カード ──
+                        _buildCard(
+                          context,
+                          icon: Icons.biotech_rounded,
+                          title: 'DNA 配列',
+                          trailing: IconButton(
+                            onPressed: () {
+                              Clipboard.setData(
+                                ClipboardData(text: dnaSequence),
+                              );
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: const Text('DNA配列をコピーしました'),
+                                  backgroundColor: AppTheme.surfaceDark,
+                                  behavior: SnackBarBehavior.floating,
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                ),
+                              );
+                            },
+                            icon: const Icon(
+                              Icons.copy_rounded,
+                              color: AppTheme.accentCyan,
+                              size: 20,
+                            ),
+                            tooltip: 'コピー',
+                          ),
+                          child: SelectableText(
+                            _formatDna(dnaSequence),
+                            style: Theme.of(
+                              context,
+                            ).textTheme.bodyLarge?.copyWith(
+                              fontFamily: 'monospace',
+                              fontSize: 18,
+                              letterSpacing: 2,
+                              height: 1.8,
+                              color: AppTheme.primaryGreen,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+
+                        const SizedBox(height: 20),
+
+                        // ── 塩基組成カード ──
+                        _buildCard(
+                          context,
+                          icon: Icons.pie_chart_rounded,
+                          title: '塩基組成',
+                          child: _buildComposition(context),
+                        ),
+
+                        const SizedBox(height: 20),
+
+                        // ── 文字数情報 ──
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 12,
+                          ),
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(12),
+                            color: AppTheme.surfaceDark.withValues(alpha: 0.5),
+                          ),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                            children: [
+                              _buildStat(
+                                context,
+                                label: '入力文字数',
+                                value: '${inputText.length}',
+                              ),
+                              Container(
+                                width: 1,
+                                height: 32,
+                                color: AppTheme.textSecondary.withValues(
+                                  alpha: 0.3,
+                                ),
+                              ),
+                              _buildStat(
+                                context,
+                                label: '塩基数',
+                                value: '${dnaSequence.length}',
+                              ),
+                            ],
+                          ),
+                        ),
+
+                        const SizedBox(height: 40),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// カード UI を構築するヘルパー
+  Widget _buildCard(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required Widget child,
+    Widget? trailing,
+  }) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            AppTheme.cardDark.withValues(alpha: 0.8),
+            AppTheme.surfaceDark.withValues(alpha: 0.6),
+          ],
+        ),
+        border: Border.all(
+          color: AppTheme.primaryGreen.withValues(alpha: 0.15),
+          width: 1,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: AppTheme.primaryGreen.withValues(alpha: 0.05),
+            blurRadius: 30,
+            spreadRadius: 5,
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, color: AppTheme.primaryGreen, size: 24),
+              const SizedBox(width: 8),
+              Text(
+                title,
+                style: Theme.of(
+                  context,
+                ).textTheme.headlineMedium?.copyWith(fontSize: 18),
+              ),
+              if (trailing != null) ...[const Spacer(), trailing],
+            ],
+          ),
+          const SizedBox(height: 16),
+          child,
+        ],
+      ),
+    );
+  }
+
+  /// DNA 配列を 4 文字ごとにスペースで区切って見やすくする
+  String _formatDna(String dna) {
+    final buffer = StringBuffer();
+    for (int i = 0; i < dna.length; i++) {
+      buffer.write(dna[i]);
+      if ((i + 1) % 4 == 0 && i + 1 != dna.length) {
+        buffer.write(' ');
+      }
+    }
+    return buffer.toString();
+  }
+
+  /// 各塩基の割合を表示するウィジェット
+  Widget _buildComposition(BuildContext context) {
+    final total = dnaSequence.length;
+    final counts = {'A': 0, 'T': 0, 'G': 0, 'C': 0};
+    for (final ch in dnaSequence.split('')) {
+      counts[ch] = (counts[ch] ?? 0) + 1;
+    }
+
+    const baseColors = {
+      'A': Color(0xFF4CAF50), // 緑
+      'T': Color(0xFFFF7043), // オレンジ
+      'G': Color(0xFF42A5F5), // 青
+      'C': Color(0xFFAB47BC), // 紫
+    };
+
+    return Column(
+      children:
+          ['A', 'T', 'G', 'C'].map((base) {
+            final count = counts[base]!;
+            final ratio = total > 0 ? count / total : 0.0;
+            return _buildBaseRow(
+              context,
+              base: base,
+              count: count,
+              ratio: ratio,
+              color: baseColors[base]!,
+            );
+          }).toList(),
+    );
+  }
+
+  Widget _buildBaseRow(
+    BuildContext context, {
+    required String base,
+    required int count,
+    required double ratio,
+    required Color color,
+  }) {
+    final pct = (ratio * 100).toStringAsFixed(1);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        children: [
+          // 塩基ラベル
+          SizedBox(
+            width: 28,
+            child: Text(
+              base,
+              style: TextStyle(
+                color: color,
+                fontSize: 18,
+                fontWeight: FontWeight.w800,
+                fontFamily: 'monospace',
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          // プログレスバー
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(6),
+              child: SizedBox(
+                height: 12,
+                child: LinearProgressIndicator(
+                  value: ratio,
+                  backgroundColor: AppTheme.cardDark,
+                  valueColor: AlwaysStoppedAnimation<Color>(color),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          // パーセント
+          SizedBox(
+            width: 56,
+            child: Text(
+              '$pct%',
+              textAlign: TextAlign.right,
+              style: TextStyle(
+                color: AppTheme.textSecondary.withValues(alpha: 0.9),
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStat(
+    BuildContext context, {
+    required String label,
+    required String value,
+  }) {
+    return Column(
+      children: [
+        Text(
+          value,
+          style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+            fontSize: 22,
+            color: AppTheme.accentCyan,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          label,
+          style: TextStyle(
+            color: AppTheme.textSecondary.withValues(alpha: 0.8),
+            fontSize: 12,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/app/screens/result_screen.dart
+++ b/lib/app/screens/result_screen.dart
@@ -178,6 +178,66 @@ class ResultScreen extends StatelessWidget {
                           ),
                         ),
 
+                        const SizedBox(height: 32),
+
+                        // ── 似ている塩基配列を探すボタン ──
+                        SizedBox(
+                          width: double.infinity,
+                          height: 56,
+                          child: Container(
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(16),
+                              gradient: const LinearGradient(
+                                colors: [
+                                  AppTheme.primaryGreen,
+                                  AppTheme.accentCyan,
+                                ],
+                              ),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: AppTheme.primaryGreen.withValues(
+                                    alpha: 0.4,
+                                  ),
+                                  blurRadius: 20,
+                                  offset: const Offset(0, 4),
+                                ),
+                              ],
+                            ),
+                            child: ElevatedButton.icon(
+                              onPressed: () {
+                                // TODO: NCBI BLAST 検索を実装する
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: const Text('この機能は準備中です'),
+                                    backgroundColor: AppTheme.surfaceDark,
+                                    behavior: SnackBarBehavior.floating,
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(12),
+                                    ),
+                                  ),
+                                );
+                              },
+                              icon: const Icon(Icons.search_rounded, size: 22),
+                              label: const Text(
+                                '似ている塩基配列を探す',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w700,
+                                  letterSpacing: 0.5,
+                                ),
+                              ),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: Colors.transparent,
+                                shadowColor: Colors.transparent,
+                                foregroundColor: Colors.white,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+
                         const SizedBox(height: 40),
                       ],
                     ),

--- a/lib/app/screens/search_loading_screen.dart
+++ b/lib/app/screens/search_loading_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:genoru/app/screens/search_result_screen.dart';
 import 'package:genoru/app/theme/app_theme.dart';
 import 'package:genoru/app/widgets/dna_background.dart';
 
@@ -66,6 +67,20 @@ class _SearchLoadingScreenState extends State<SearchLoadingScreen>
     });
 
     // TODO: ここで実際の BLAST 検索を開始し、完了したら結果画面へ遷移
+    _simulateSearchAndNavigate();
+  }
+
+  Future<void> _simulateSearchAndNavigate() async {
+    // API接続の代わりにダミーの待機時間を設ける
+    await Future.delayed(const Duration(seconds: 4));
+
+    if (!mounted) return;
+
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (_) => SearchResultScreen(searchSequence: widget.dnaSequence),
+      ),
+    );
   }
 
   @override

--- a/lib/app/screens/search_loading_screen.dart
+++ b/lib/app/screens/search_loading_screen.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+import 'package:genoru/app/theme/app_theme.dart';
+import 'package:genoru/app/widgets/dna_background.dart';
+
+/// BLAST 検索中に表示するローディング画面
+class SearchLoadingScreen extends StatefulWidget {
+  final String dnaSequence;
+
+  const SearchLoadingScreen({super.key, required this.dnaSequence});
+
+  @override
+  State<SearchLoadingScreen> createState() => _SearchLoadingScreenState();
+}
+
+class _SearchLoadingScreenState extends State<SearchLoadingScreen>
+    with TickerProviderStateMixin {
+  late AnimationController _rotateController;
+  late AnimationController _pulseController;
+  late AnimationController _dotsController;
+  late Animation<double> _pulseAnimation;
+
+  final List<String> _statusMessages = [
+    'NCBI データベースに接続中…',
+    '塩基配列を送信中…',
+    'BLAST 検索を実行中…',
+    '類似配列を解析中…',
+    '結果を取得中…',
+  ];
+  int _currentMessageIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // DNA アイコン回転
+    _rotateController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 3),
+    )..repeat();
+
+    // パルスアニメーション
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    )..repeat(reverse: true);
+
+    _pulseAnimation = Tween<double>(begin: 0.85, end: 1.15).animate(
+      CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
+    );
+
+    // ステータスメッセージ切り替え
+    _dotsController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 4),
+    )..repeat();
+
+    _dotsController.addListener(() {
+      final newIndex =
+          (_dotsController.value * _statusMessages.length).floor() %
+          _statusMessages.length;
+      if (newIndex != _currentMessageIndex) {
+        setState(() {
+          _currentMessageIndex = newIndex;
+        });
+      }
+    });
+
+    // TODO: ここで実際の BLAST 検索を開始し、完了したら結果画面へ遷移
+  }
+
+  @override
+  void dispose() {
+    _rotateController.dispose();
+    _pulseController.dispose();
+    _dotsController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          const DnaBackground(),
+          SafeArea(
+            child: Column(
+              children: [
+                // ── ヘッダー ──
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 8,
+                  ),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        icon: const Icon(
+                          Icons.arrow_back_ios_rounded,
+                          color: AppTheme.textPrimary,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      ShaderMask(
+                        shaderCallback:
+                            (bounds) => const LinearGradient(
+                              colors: [
+                                AppTheme.primaryGreen,
+                                AppTheme.accentCyan,
+                              ],
+                            ).createShader(bounds),
+                        child: Text(
+                          '🔍 検索中',
+                          style: Theme.of(
+                            context,
+                          ).textTheme.headlineMedium?.copyWith(
+                            fontSize: 22,
+                            fontWeight: FontWeight.w700,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+                // ── ローディングコンテンツ ──
+                Expanded(
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 32),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          // 回転する DNA アイコン
+                          AnimatedBuilder(
+                            animation: _pulseAnimation,
+                            builder: (context, child) {
+                              return Transform.scale(
+                                scale: _pulseAnimation.value,
+                                child: child,
+                              );
+                            },
+                            child: RotationTransition(
+                              turns: _rotateController,
+                              child: ShaderMask(
+                                shaderCallback:
+                                    (bounds) => const LinearGradient(
+                                      begin: Alignment.topLeft,
+                                      end: Alignment.bottomRight,
+                                      colors: [
+                                        AppTheme.primaryGreen,
+                                        AppTheme.accentCyan,
+                                      ],
+                                    ).createShader(bounds),
+                                child: const Icon(
+                                  Icons.biotech_rounded,
+                                  size: 80,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+
+                          const SizedBox(height: 40),
+
+                          // ステータスメッセージ
+                          AnimatedSwitcher(
+                            duration: const Duration(milliseconds: 400),
+                            child: Text(
+                              _statusMessages[_currentMessageIndex],
+                              key: ValueKey<int>(_currentMessageIndex),
+                              textAlign: TextAlign.center,
+                              style: Theme.of(
+                                context,
+                              ).textTheme.bodyLarge?.copyWith(
+                                color: AppTheme.textPrimary,
+                                fontSize: 16,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ),
+
+                          const SizedBox(height: 24),
+
+                          // プログレスバー
+                          SizedBox(
+                            width: 200,
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: LinearProgressIndicator(
+                                backgroundColor: AppTheme.cardDark.withValues(
+                                  alpha: 0.8,
+                                ),
+                                valueColor: const AlwaysStoppedAnimation<Color>(
+                                  AppTheme.primaryGreen,
+                                ),
+                                minHeight: 4,
+                              ),
+                            ),
+                          ),
+
+                          const SizedBox(height: 48),
+
+                          // 検索中の配列プレビュー
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 20,
+                              vertical: 16,
+                            ),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(16),
+                              color: AppTheme.cardDark.withValues(alpha: 0.6),
+                              border: Border.all(
+                                color: AppTheme.primaryGreen.withValues(
+                                  alpha: 0.1,
+                                ),
+                              ),
+                            ),
+                            child: Column(
+                              children: [
+                                Text(
+                                  '検索配列',
+                                  style: TextStyle(
+                                    color: AppTheme.textSecondary.withValues(
+                                      alpha: 0.7,
+                                    ),
+                                    fontSize: 12,
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                Text(
+                                  _previewSequence(widget.dnaSequence),
+                                  textAlign: TextAlign.center,
+                                  style: const TextStyle(
+                                    fontFamily: 'monospace',
+                                    fontSize: 14,
+                                    letterSpacing: 1.5,
+                                    color: AppTheme.primaryGreen,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  '${widget.dnaSequence.length} bp',
+                                  style: TextStyle(
+                                    color: AppTheme.textSecondary.withValues(
+                                      alpha: 0.6,
+                                    ),
+                                    fontSize: 12,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+
+                          const SizedBox(height: 32),
+
+                          // 注意テキスト
+                          Text(
+                            'NCBI BLAST で類似配列を検索しています\n通常 30 秒〜数分かかります',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              color: AppTheme.textSecondary.withValues(
+                                alpha: 0.6,
+                              ),
+                              fontSize: 12,
+                              height: 1.5,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 配列の先頭と末尾を表示し、長い場合は中間を省略
+  String _previewSequence(String seq) {
+    if (seq.length <= 24) return seq;
+    final head = seq.substring(0, 12);
+    final tail = seq.substring(seq.length - 12);
+    return '$head … $tail';
+  }
+}

--- a/lib/app/screens/search_result_screen.dart
+++ b/lib/app/screens/search_result_screen.dart
@@ -1,0 +1,306 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:genoru/app/theme/app_theme.dart';
+import 'package:genoru/app/widgets/dna_background.dart';
+
+/// 検索結果のモックモデル
+class SearchResultItem {
+  final String accession;
+  final String title;
+  final double identity;
+  final double coverage;
+  final double eValue;
+
+  SearchResultItem({
+    required this.accession,
+    required this.title,
+    required this.identity,
+    required this.coverage,
+    required this.eValue,
+  });
+}
+
+/// BLAST検索結果を表示する画面
+class SearchResultScreen extends StatelessWidget {
+  final String searchSequence;
+
+  SearchResultScreen({super.key, required this.searchSequence});
+
+  // モックデータ
+  final List<SearchResultItem> _mockResults = [
+    SearchResultItem(
+      accession: 'NM_000059.4',
+      title: 'Homo sapiens BRCA2 DNA repair associated (BRCA2), mRNA',
+      identity: 100.0,
+      coverage: 100.0,
+      eValue: 0.0,
+    ),
+    SearchResultItem(
+      accession: 'NM_001006610.1',
+      title: 'Pan troglodytes BRCA2 DNA repair associated (BRCA2), mRNA',
+      identity: 98.5,
+      coverage: 99.0,
+      eValue: 1e-120,
+    ),
+    SearchResultItem(
+      accession: 'NM_001082186.1',
+      title: 'Mus musculus BRCA2 DNA repair associated (BRCA2), mRNA',
+      identity: 85.2,
+      coverage: 92.5,
+      eValue: 2e-75,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          const DnaBackground(),
+          SafeArea(
+            child: Column(
+              children: [
+                // ── ヘッダー ──
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 8,
+                  ),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        icon: const Icon(
+                          Icons.arrow_back_ios_rounded,
+                          color: AppTheme.textPrimary,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      ShaderMask(
+                        shaderCallback:
+                            (bounds) => const LinearGradient(
+                              colors: [
+                                AppTheme.primaryGreen,
+                                AppTheme.accentCyan,
+                              ],
+                            ).createShader(bounds),
+                        child: Text(
+                          '📊 検索結果',
+                          style: Theme.of(
+                            context,
+                          ).textTheme.headlineMedium?.copyWith(
+                            fontSize: 22,
+                            fontWeight: FontWeight.w700,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+                // ── 結果リスト ──
+                Expanded(
+                  child: ListView.builder(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 24,
+                      vertical: 16,
+                    ),
+                    itemCount: _mockResults.length + 1, // +1 for the header
+                    itemBuilder: (context, index) {
+                      if (index == 0) {
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 24),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                '${_mockResults.length} 件の類似配列が見つかりました',
+                                style: Theme.of(
+                                  context,
+                                ).textTheme.headlineMedium?.copyWith(
+                                  fontSize: 18,
+                                  color: AppTheme.textPrimary,
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                              Text(
+                                '検索クエリ: ${_previewSequence(searchSequence)}',
+                                style: TextStyle(
+                                  color: AppTheme.textSecondary.withValues(
+                                    alpha: 0.8,
+                                  ),
+                                  fontFamily: 'monospace',
+                                ),
+                              ),
+                            ],
+                          ),
+                        );
+                      }
+
+                      final item = _mockResults[index - 1];
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 16),
+                        child: _buildResultCard(context, item: item),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 結果アイテムのカードUI
+  Widget _buildResultCard(
+    BuildContext context, {
+    required SearchResultItem item,
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            AppTheme.cardDark.withValues(alpha: 0.8),
+            AppTheme.surfaceDark.withValues(alpha: 0.6),
+          ],
+        ),
+        border: Border.all(
+          color: AppTheme.primaryGreen.withValues(alpha: 0.2),
+          width: 1,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: AppTheme.primaryGreen.withValues(alpha: 0.05),
+            blurRadius: 20,
+            spreadRadius: 2,
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  item.title,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: AppTheme.textPrimary,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              color: AppTheme.primaryGreen.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: AppTheme.primaryGreen.withValues(alpha: 0.3),
+              ),
+            ),
+            child: Text(
+              'Accession: ${item.accession}',
+              style: const TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 13,
+                color: AppTheme.accentCyan,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              _buildStatMetric(
+                label: '一致率 (Identity)',
+                value: '${item.identity.toStringAsFixed(1)}%',
+                color: _getColorForPercentage(item.identity),
+              ),
+              Container(
+                width: 1,
+                height: 30,
+                color: AppTheme.textSecondary.withValues(alpha: 0.3),
+              ),
+              _buildStatMetric(
+                label: 'カバレッジ',
+                value: '${item.coverage.toStringAsFixed(1)}%',
+                color: _getColorForPercentage(item.coverage),
+              ),
+              Container(
+                width: 1,
+                height: 30,
+                color: AppTheme.textSecondary.withValues(alpha: 0.3),
+              ),
+              _buildStatMetric(
+                label: 'E-value',
+                value:
+                    item.eValue == 0.0
+                        ? '0.0'
+                        : item.eValue.toStringAsExponential(1),
+                color: AppTheme.textPrimary,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatMetric({
+    required String label,
+    required String value,
+    required Color color,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: TextStyle(
+            color: AppTheme.textSecondary.withValues(alpha: 0.8),
+            fontSize: 11,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+            color: color,
+            fontFamily: 'monospace',
+          ),
+        ),
+      ],
+    );
+  }
+
+  Color _getColorForPercentage(double percentage) {
+    if (percentage >= 95) return const Color(0xFF4CAF50); // Green
+    if (percentage >= 80) return const Color(0xFFFFB300); // Amber
+    return const Color(0xFFE53935); // Red
+  }
+
+  /// 配列の先頭と末尾を表示し、長い場合は中間を省略
+  String _previewSequence(String seq) {
+    if (seq.length <= 20) return seq;
+    final head = seq.substring(0, 8);
+    final tail = seq.substring(seq.length - 8);
+    return '$head...$tail';
+  }
+}

--- a/lib/app/screens/search_result_screen.dart
+++ b/lib/app/screens/search_result_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:genoru/app/theme/app_theme.dart';
 import 'package:genoru/app/widgets/dna_background.dart';
 
@@ -42,13 +41,13 @@ class SearchResultScreen extends StatelessWidget {
       coverage: 99.0,
       eValue: 1e-120,
     ),
-    SearchResultItem(
-      accession: 'NM_001082186.1',
-      title: 'Mus musculus BRCA2 DNA repair associated (BRCA2), mRNA',
-      identity: 85.2,
-      coverage: 92.5,
-      eValue: 2e-75,
-    ),
+    // SearchResultItem(
+    //   accession: 'NM_001082186.1',
+    //   title: 'Mus musculus BRCA2 DNA repair associated (BRCA2), mRNA',
+    //   identity: 85.2,
+    //   coverage: 92.5,
+    //   eValue: 2e-75,
+    // ),
   ];
 
   @override
@@ -102,11 +101,14 @@ class SearchResultScreen extends StatelessWidget {
                 // ── 結果リスト ──
                 Expanded(
                   child: ListView.builder(
+                    physics: const AlwaysScrollableScrollPhysics(),
                     padding: const EdgeInsets.symmetric(
                       horizontal: 24,
                       vertical: 16,
                     ),
-                    itemCount: _mockResults.length + 1, // +1 for the header
+                    itemCount:
+                        _mockResults.length +
+                        2, // +1 for the header, +1 for the footer
                     itemBuilder: (context, index) {
                       if (index == 0) {
                         return Padding(
@@ -134,6 +136,44 @@ class SearchResultScreen extends StatelessWidget {
                                 ),
                               ),
                             ],
+                          ),
+                        );
+                      }
+
+                      if (index == _mockResults.length + 1) {
+                        return Padding(
+                          padding: const EdgeInsets.only(top: 16, bottom: 40),
+                          child: SizedBox(
+                            width: double.infinity,
+                            height: 56,
+                            child: OutlinedButton.icon(
+                              onPressed: () {
+                                Navigator.of(
+                                  context,
+                                ).popUntil((route) => route.isFirst);
+                              },
+                              icon: const Icon(Icons.home_rounded, size: 22),
+                              label: const Text(
+                                '最初の画面に戻る',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w700,
+                                  letterSpacing: 0.5,
+                                ),
+                              ),
+                              style: OutlinedButton.styleFrom(
+                                foregroundColor: AppTheme.accentCyan,
+                                side: BorderSide(
+                                  color: AppTheme.accentCyan.withValues(
+                                    alpha: 0.5,
+                                  ),
+                                  width: 2,
+                                ),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                              ),
+                            ),
                           ),
                         );
                       }

--- a/lib/app/theme/app_theme.dart
+++ b/lib/app/theme/app_theme.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AppTheme {
+  AppTheme._();
+
+  // ── カラーパレット ──
+  static const Color primaryGreen = Color(0xFF00E676);
+  static const Color accentCyan = Color(0xFF00BCD4);
+  static const Color backgroundDark = Color(0xFF0A0E27);
+  static const Color surfaceDark = Color(0xFF131A3A);
+  static const Color cardDark = Color(0xFF1A2244);
+  static const Color textPrimary = Color(0xFFF0F0F0);
+  static const Color textSecondary = Color(0xFF8892B0);
+  static const Color errorRed = Color(0xFFFF5252);
+
+  static ThemeData get darkTheme {
+    return ThemeData(
+      brightness: Brightness.dark,
+      scaffoldBackgroundColor: backgroundDark,
+      colorScheme: const ColorScheme.dark(
+        primary: primaryGreen,
+        secondary: accentCyan,
+        surface: surfaceDark,
+        error: errorRed,
+      ),
+      textTheme: GoogleFonts.notoSansJpTextTheme(
+        const TextTheme(
+          headlineLarge: TextStyle(
+            color: textPrimary,
+            fontSize: 28,
+            fontWeight: FontWeight.w700,
+          ),
+          headlineMedium: TextStyle(
+            color: textPrimary,
+            fontSize: 22,
+            fontWeight: FontWeight.w600,
+          ),
+          bodyLarge: TextStyle(color: textPrimary, fontSize: 16),
+          bodyMedium: TextStyle(color: textSecondary, fontSize: 14),
+          labelLarge: TextStyle(
+            color: textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: cardDark,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide.none,
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: primaryGreen, width: 2),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: errorRed, width: 1.5),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: errorRed, width: 2),
+        ),
+        hintStyle: const TextStyle(color: textSecondary),
+        contentPadding: const EdgeInsets.all(20),
+      ),
+    );
+  }
+}

--- a/lib/app/utils/dna_converter.dart
+++ b/lib/app/utils/dna_converter.dart
@@ -1,0 +1,33 @@
+/// 文字列を DNA 塩基配列 (ATGC) に変換するユーティリティ
+///
+/// 変換手順:
+///   1. 各文字の Unicode コードポイントを取得
+///   2. 各コードポイントを 8 ビット（以上）のバイナリ文字列に変換
+///   3. バイナリ文字列を 2 ビットずつ区切る
+///   4. 00 → A, 01 → T, 10 → G, 11 → C にマッピング
+class DnaConverter {
+  DnaConverter._();
+
+  static const _baseMap = {'00': 'A', '01': 'T', '10': 'G', '11': 'C'};
+
+  /// [input] を DNA 配列に変換して返す
+  static String convertToDna(String input) {
+    final buffer = StringBuffer();
+
+    for (final codeUnit in input.codeUnits) {
+      // 8 ビット以上のバイナリ文字列（偶数桁になるよう左をゼロ埋め）
+      String binary = codeUnit.toRadixString(2);
+      if (binary.length % 2 != 0) {
+        binary = '0$binary';
+      }
+
+      // 2 ビットずつ塩基に変換
+      for (int i = 0; i < binary.length; i += 2) {
+        final pair = binary.substring(i, i + 2);
+        buffer.write(_baseMap[pair]);
+      }
+    }
+
+    return buffer.toString();
+  }
+}

--- a/lib/app/widgets/dna_background.dart
+++ b/lib/app/widgets/dna_background.dart
@@ -1,0 +1,152 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:genoru/app/theme/app_theme.dart';
+
+/// DNA螺旋をモチーフにしたアニメーション背景
+class DnaBackground extends StatefulWidget {
+  const DnaBackground({super.key});
+
+  @override
+  State<DnaBackground> createState() => _DnaBackgroundState();
+}
+
+class _DnaBackgroundState extends State<DnaBackground>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 8),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        return CustomPaint(
+          painter: _DnaBackgroundPainter(animationValue: _controller.value),
+          size: Size.infinite,
+        );
+      },
+    );
+  }
+}
+
+class _DnaBackgroundPainter extends CustomPainter {
+  final double animationValue;
+
+  _DnaBackgroundPainter({required this.animationValue});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // 背景グラデーション
+    final bgPaint =
+        Paint()
+          ..shader = LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              AppTheme.backgroundDark,
+              const Color(0xFF0D1333),
+              AppTheme.backgroundDark,
+            ],
+          ).createShader(Rect.fromLTWH(0, 0, size.width, size.height));
+
+    canvas.drawRect(Rect.fromLTWH(0, 0, size.width, size.height), bgPaint);
+
+    // DNA螺旋を描画
+    _drawDnaHelix(canvas, size, size.width * 0.15, 0.6);
+    _drawDnaHelix(canvas, size, size.width * 0.85, 0.4);
+
+    // 浮遊する塩基文字
+    _drawFloatingBases(canvas, size);
+  }
+
+  void _drawDnaHelix(Canvas canvas, Size size, double xCenter, double opacity) {
+    final strandPaint1 =
+        Paint()
+          ..color = AppTheme.primaryGreen.withValues(alpha: opacity * 0.15)
+          ..strokeWidth = 2
+          ..style = PaintingStyle.stroke;
+
+    final strandPaint2 =
+        Paint()
+          ..color = AppTheme.accentCyan.withValues(alpha: opacity * 0.15)
+          ..strokeWidth = 2
+          ..style = PaintingStyle.stroke;
+
+    final path1 = Path();
+    final path2 = Path();
+    final amplitude = 30.0;
+    final offset = animationValue * 2 * pi;
+
+    for (double y = -20; y < size.height + 20; y += 1) {
+      final x1 = xCenter + amplitude * sin((y / 60) + offset);
+      final x2 = xCenter + amplitude * sin((y / 60) + offset + pi);
+
+      if (y == -20) {
+        path1.moveTo(x1, y);
+        path2.moveTo(x2, y);
+      } else {
+        path1.lineTo(x1, y);
+        path2.lineTo(x2, y);
+      }
+
+      // 塩基対の横線を一定間隔で描画
+      if (y.toInt() % 40 == 0) {
+        final bridgePaint =
+            Paint()
+              ..color = AppTheme.primaryGreen.withValues(alpha: opacity * 0.08)
+              ..strokeWidth = 1;
+        canvas.drawLine(Offset(x1, y), Offset(x2, y), bridgePaint);
+      }
+    }
+
+    canvas.drawPath(path1, strandPaint1);
+    canvas.drawPath(path2, strandPaint2);
+  }
+
+  void _drawFloatingBases(Canvas canvas, Size size) {
+    final bases = ['A', 'T', 'G', 'C'];
+    final random = Random(42); // 固定シードで安定した位置
+
+    for (int i = 0; i < 12; i++) {
+      final x = random.nextDouble() * size.width;
+      final baseY = random.nextDouble() * size.height;
+      final speed = 0.3 + random.nextDouble() * 0.7;
+      final y = (baseY + animationValue * size.height * speed) % size.height;
+      final alpha = 0.05 + random.nextDouble() * 0.08;
+
+      final textPainter = TextPainter(
+        text: TextSpan(
+          text: bases[i % 4],
+          style: TextStyle(
+            color: (i % 2 == 0 ? AppTheme.primaryGreen : AppTheme.accentCyan)
+                .withValues(alpha: alpha),
+            fontSize: 14 + random.nextDouble() * 10,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+
+      textPainter.paint(canvas, Offset(x, y));
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _DnaBackgroundPainter oldDelegate) {
+    return oldDelegate.animationValue != animationValue;
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,13 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:genoru/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('GenoruApp smoke test', (WidgetTester tester) async {
+    await tester.pumpWidget(const GenoruApp());
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // InputScreenが表示されることを確認
+    expect(find.text('🧬 ゲノる'), findsOneWidget);
+    expect(find.text('あなたの言葉をDNAに変換しよう'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 概要
検索結果を表示する画面（SearchResultScreen）のUIを実装しました。

## 対応内容
- 検索結果のリスト表示（Card/List形式）
- 1件あたりの表示項目：生物名 / 一致率（Identity）/（任意でCoverage・E-value）
- 結果が多い場合でもスクロール可能なレイアウトに対応
- 0件（Empty）状態の表示を追加
- エラー（Error）状態の表示を追加（再検索/戻る導線を用意）

## 動作確認
- [ ] 仮データで結果リストが表示されること
- [ ] 多件数でもスクロールできること
- [ ] 0件時にEmpty表示になること
- [ ] エラー時にError表示になること

## スクリーンショット
<img width="506" height="960" alt="スクリーンショット 2026-03-09 23 33 19" src="https://github.com/user-attachments/assets/56d47563-f5a1-4437-aa04-38a3855177aa" />